### PR TITLE
fix(#4): remove iPadOS 18 native floating tab bar appearance

### DIFF
--- a/Sources/CustomTabView/iOS/UITabBarControllerRepresentable.swift
+++ b/Sources/CustomTabView/iOS/UITabBarControllerRepresentable.swift
@@ -19,6 +19,9 @@ struct UITabBarControllerRepresentable: UIViewControllerRepresentable {
         tabBarController.setViewControllers(controlledViews, animated: false)
         tabBarController.selectedIndex = selectedTabIndex
         tabBarController.tabBar.isHidden = true
+        if #available(iOS 18.0, *) {
+            tabBarController.isTabBarHidden = true
+        }
         return tabBarController
     }
     


### PR DESCRIPTION
Fixes #4 